### PR TITLE
Only set trust cookie for users with enabled devices

### DIFF
--- a/src/django_agent_trust/middleware.py
+++ b/src/django_agent_trust/middleware.py
@@ -5,6 +5,7 @@ import json
 import logging
 
 from django.core.exceptions import ImproperlyConfigured
+from django_otp import user_has_device
 
 from .conf import settings
 from .models import SESSION_TOKEN_KEY, Agent, AgentSettings
@@ -37,7 +38,7 @@ class AgentMiddleware(object):
         response = self.get_response(request)
 
         agent = getattr(request, 'agent', None)
-        if agent and agent.user.is_authenticated:
+        if agent is not None and request.user.is_authenticated and user_has_device(agent.user):
             self._save_agent(agent, response)
 
         return response


### PR DESCRIPTION
We have a project where there are a multitude of support accounts that a handful of people use. Every week or so, they get a "400 Bad Request - Request Header or Cookie Too Large" error and have to clear out all cookies

ToDo
- [ ] tests