### PR TITLE
Don't run signal when loading fixtures

### DIFF
--- a/src/django_agent_trust/signals.py
+++ b/src/django_agent_trust/signals.py
@@ -8,7 +8,7 @@ from .models import AgentSettings
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
 def init_agent_settings(sender, instance, created=False, **kwargs):
     if kwargs.get("raw"):
-        return 
+        return
 
     if instance and created:
         AgentSettings.objects.ensure_for_user(instance)

--- a/src/django_agent_trust/signals.py
+++ b/src/django_agent_trust/signals.py
@@ -7,5 +7,8 @@ from .models import AgentSettings
 
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
 def init_agent_settings(sender, instance, created=False, **kwargs):
+    if kwargs.get("raw"):
+        return 
+
     if instance and created:
         AgentSettings.objects.ensure_for_user(instance)


### PR DESCRIPTION
This can create a race condition where the signal creates settings that the fixture will create in future.